### PR TITLE
fix: build with clang>=15 (OpenSSL 1.1.1u)

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1067,6 +1067,8 @@ struct ssl_ctx_st {
 
 #include "claim-interface.h"
 
+void fill_claim(SSL *s, Claim* claim);
+
 struct ssl_st {
     void (* claim)(Claim claim, void* ctx);
     void* claim_ctx;


### PR DESCRIPTION
In `ssl/statem/statem.c` the function fill_claim was used without a previous declaration. This causes modern versions of clang to report an error and stop the build process.

We add the missing declaration and include the rest of the claims interface, where the C-types related to claims are defined.

see also https://github.com/tlspuffin/tlspuffin/pull/291 for upstream discussion