### PR TITLE
fix: modify claims implementation to work with OpenSSL 3.2

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1199,7 +1199,6 @@ typedef struct cert_pkey_st CERT_PKEY;
 
 #include "claim-interface.h"
 
-
 void fill_claim(SSL *s, Claim* claim);
 
 struct ssl_st {

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -759,7 +759,7 @@ static SUB_STATE_RETURN read_state_machine(SSL_CONNECTION *s)
                         break;
                 }
 
-                fill_claim(s, &claim);
+                fill_claim(ssl, &claim);
                 s->claim(claim, s->claim_ctx);
             }
 
@@ -1066,7 +1066,7 @@ static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
                     break;
             }
 
-            fill_claim(s, &claim);
+            fill_claim(ssl, &claim);
             s->claim(claim, s->claim_ctx);
 
             if (!ssl_close_construct_packet(s, &pkt, mt)


### PR DESCRIPTION
In OpenSSL 3.2 the internal struct representing the SSL connection was split into several structs. As a consequence, the code used in previous versions to insert our claims is not compatible with this version.

This adapts the claims implementation to use the new internal architecture.